### PR TITLE
Replace badges whose upstreams were failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Parse Hex To RGBA
 
 [![CI](https://github.com/iagobelo/parse-hex-to-rgba/actions/workflows/ci.yml/badge.svg)](https://github.com/iagobelo/parse-hex-to-rgba/actions/workflows/ci.yml)
-[![npm version](https://badgen.net/npm/v/parse-hex-to-rgba)](https://www.npmjs.com/package/parse-hex-to-rgba)
-[![License](https://badgen.net/github/license/iagobelo/parse-hex-to-rgba)](./LICENSE)
-[![Library minified size](https://badgen.net/bundlephobia/min/parse-hex-to-rgba)](https://bundlephobia.com/result?p=parse-hex-to-rgba)
-[![Library minified + gzipped size](https://badgen.net/bundlephobia/minzip/parse-hex-to-rgba)](https://bundlephobia.com/result?p=parse-hex-to-rgba)
+[![npm version](https://img.shields.io/npm/v/parse-hex-to-rgba)](https://www.npmjs.com/package/parse-hex-to-rgba)
+[![Bundle size](https://img.shields.io/bundlejs/size/parse-hex-to-rgba)](https://bundlejs.com/?q=parse-hex-to-rgba)
+[![Downloads](https://img.shields.io/npm/dm/parse-hex-to-rgba)](https://www.npmjs.com/package/parse-hex-to-rgba)
+[![License](https://img.shields.io/npm/l/parse-hex-to-rgba)](./LICENSE)
 
 Converts a `HEX` color to a `RGBA` color. Zero dependencies, ships ESM, CJS and
 UMD builds with TypeScript types.


### PR DESCRIPTION
Three of the five badges in the README rendered as errors:

| Badge | Was | Now |
| --- | --- | --- |
| License | `badgen/github/license` → **403** | `shields.io/npm/l` → MIT |
| Min size | `badgen/bundlephobia/min` → **429** | *removed (redundant)* |
| Minzip size | `badgen/bundlephobia/minzip` → **429** | `shields.io/bundlejs/size` → 456 B |
| Version | `badgen/npm/v` | `shields.io/npm/v` |
| Downloads | — | `shields.io/npm/dm` |

## Why not just swap the badge provider

The two failures have different causes, and only one is about the provider.

**The license 403** came from badgen querying the GitHub API and hitting its rate limit — it is intermittent, and returns MIT correctly on a retry. Reading the license from the npm package metadata instead takes the GitHub API out of that path, so the failure mode stops existing rather than becoming less frequent.

**The Bundlephobia 429 is the upstream itself.** shields.io returns `rate limited by upstream service` for the same lookup, so moving providers would have changed nothing. bundlejs is maintained and responds with real data.

## Verification

All five endpoints were fetched and their rendered text checked:

```
200  CI ........................ passing
200  npm/v ..................... v1.0.0
200  bundlejs/size ............. 456 B (gzip)
200  npm/dm .................... 20/month
200  npm/l ..................... MIT
```

Note that this fixes the README on GitHub only. The npmjs.com package page serves the README bundled into the `1.0.0` tarball, so it keeps the old badges until the next publish — not worth a release on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
